### PR TITLE
QOL Changes

### DIFF
--- a/src/Loop.luau
+++ b/src/Loop.luau
@@ -25,6 +25,9 @@ local function systemFn(system)
 end
 
 local function systemName(system)
+	if typeof(system) == "table" then
+		return system.name
+	end
 	local fn = systemFn(system)
 	return debug.info(fn, "s") .. "->" .. debug.info(fn, "n")
 end

--- a/src/Loop.luau
+++ b/src/Loop.luau
@@ -5,6 +5,7 @@ local IS_CLIENT = RunService:IsClient()
 
 local Jecs = require(script.Parent.Parent.Jecs)
 local Jabby = require(script.Parent.Parent.Jabby)
+local Types = require(script.Parent.Types)
 
 local pair = Jecs.pair
 local topoRuntime = require(script.Parent.topoRuntime)
@@ -28,14 +29,17 @@ local function systemName(system)
 	return debug.info(fn, "s") .. "->" .. debug.info(fn, "n")
 end
 
-function Loop.new(params: { name: string, debug: any, world: any }, ...)
+function Loop.new<T...>(
+	params: { name: string, debug: Types.Entity<string>, world: Types.World },
+	...: T...
+): Types.Loop<T...>
 	local self = setmetatable({}, Loop)
 
 	self._name = params.name
 	self._debug = params.debug or Jecs.Name
 	self._running = false
 
-	self._state = { ... }
+	self._state = table.pack(...)
 	self._stateLength = select("#", ...)
 
 	self._world = params.world

--- a/src/Loop.luau
+++ b/src/Loop.luau
@@ -175,7 +175,7 @@ function Loop:begin()
 
 					local commitFailed = false
 					local thread = coroutine.create(function(...)
-						self._reporter:run(system.jabbyId, system.callback)
+						self._reporter:run(system.jabbyId, system.callback, ...)
 					end)
 
 					local success, errorValue = coroutine.resume(thread, unpack(self._state, 1, self._stateLength))

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -1,0 +1,22 @@
+local Jecs = require(script.Parent.Parent.Jecs)
+
+export type World = typeof(Jecs.World.new())
+export type Entity<T> = number & {
+	__T: T,
+}
+
+export type System = { system: () -> (), name: string } | () -> ()
+
+export type Loop<T...> = {
+	phases: {
+		RenderStepped: Entity<number>,
+		Heartbeat: Entity<number>,
+		PreSimulation: Entity<number>,
+		PreAnimation: Entity<number>,
+	},
+	phase: (after: Entity<number>) -> Entity<number>,
+	schedule: (self: Loop<T...>, system: System, phase: number?) -> System,
+	begin: (self: Loop<T...>) -> { [any]: any },
+}
+
+return {}

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -5,7 +5,7 @@ export type Entity<T> = number & {
 	__T: T,
 }
 
-export type System = { system: () -> (), name: string } | () -> ()
+export type System<T...> = { system: (T...) -> (), name: string } | (T...) -> ()
 
 export type Loop<T...> = {
 	phases: {
@@ -15,7 +15,7 @@ export type Loop<T...> = {
 		PreAnimation: Entity<number>,
 	},
 	phase: (after: Entity<number>) -> Entity<number>,
-	schedule: (self: Loop<T...>, system: System, phase: number?) -> System,
+	schedule: (self: Loop<T...>, system: System<T...>, phase: number?) -> System<T...>,
 	begin: (self: Loop<T...>) -> { [any]: any },
 }
 

--- a/src/topoRuntime.luau
+++ b/src/topoRuntime.luau
@@ -119,7 +119,7 @@ end
 	@param discriminator? any -- A unique value to additionally key by
 	@param cleanupCallback (storage: {}) -> boolean? -- A function to run when the storage for this hook is cleaned up
 ]=]
-local function useHookState(discriminator, cleanupCallback): {}
+local function useHookState(discriminator: any, cleanupCallback: (storage: {}) -> ()): {}
 	local file, line = debug.info(3, "sl")
 	local fn = debug.info(2, "f")
 

--- a/src/useEvent.luau
+++ b/src/useEvent.luau
@@ -82,6 +82,13 @@ end
 	A connection object returned by a custom event must be either a table with any of the following methods, or a cleanup function.
 ]=]
 
+type ConnectionObject = {
+	Disconnect: (() -> ())?,
+	Destroy: (() -> ())?,
+	disconnect: (() -> ())?,
+	destroy: (() -> ())?,
+} | () -> ()
+
 --[=[
 	@interface CustomEvent
 	@within Matter
@@ -91,6 +98,12 @@ end
 
 	A custom event must have any of these 3 methods.
 ]=]
+
+type CustomEvent = {
+	Connect: ((...any) -> ConnectionObject)?,
+	on: ((...any) -> ConnectionObject)?,
+	connect: ((...any) -> ConnectionObject)?,
+}
 
 --[=[
 	@within Matter
@@ -157,7 +170,10 @@ end
 	@param instance Instance | { [string]: CustomEvent } | CustomEvent -- The instance or the custom event, or a table that has the event you want to connect to
 	@param event string | RBXScriptSignal | CustomEvent -- The name of, or the actual event that you want to connect to
 ]=]
-local function useEvent(instance: Instance, event: string): () -> (number, ...any)
+local function useEvent(
+	instance: Instance | { [string]: CustomEvent } | CustomEvent,
+	event: string | RBXScriptSignal | CustomEvent
+): () -> (number, ...any)
 	assert(instance ~= nil, "Instance is nil")
 	assert(event ~= nil, "Event is nil")
 

--- a/src/useEvent.luau
+++ b/src/useEvent.luau
@@ -29,7 +29,9 @@ local function connect(object, callback, event)
 		end
 	end
 
-	error("Couldn't connect to event as no valid connect methods were found! Ensure the passed event has a 'Connect' or an 'on' method!")
+	error(
+		"Couldn't connect to event as no valid connect methods were found! Ensure the passed event has a 'Connect' or an 'on' method!"
+	)
 end
 
 local function disconnect(connection)
@@ -155,7 +157,7 @@ end
 	@param instance Instance | { [string]: CustomEvent } | CustomEvent -- The instance or the custom event, or a table that has the event you want to connect to
 	@param event string | RBXScriptSignal | CustomEvent -- The name of, or the actual event that you want to connect to
 ]=]
-local function useEvent(instance, event): () -> (number, ...any)
+local function useEvent(instance: Instance, event: string): () -> (number, ...any)
 	assert(instance ~= nil, "Instance is nil")
 	assert(event ~= nil, "Event is nil")
 

--- a/src/useThrottle.luau
+++ b/src/useThrottle.luau
@@ -36,7 +36,7 @@ end
 	@param discriminator? any -- A unique value to additionally key by
 	@return boolean -- returns true every x seconds, otherwise false
 ]=]
-local function useThrottle(seconds, discriminator)
+local function useThrottle(seconds: number, discriminator: any)
 	local storage = topoRuntime.useHookState(discriminator, cleanup)
 
 	if storage.time == nil or os.clock() - storage.time >= seconds then


### PR DESCRIPTION
### Types
- typed System and Loop
  intended to only be used by users, so it doesnt include any of the values that start with '`_`'
- typed parameters for the following functions: `useHookState` `useEvent` `useThrottle`

### Changes
- `state` gets passed to systems
  ```luau
  local loop = Jam.Loop.new({ ... }, "Hello", 9999)

  loop:schedule(function(arg0: string, arg1: number)
      print(arg0, arg1) -- Hello 9999
  end)

  loop:schedule(function(arg0: number, arg1: {}) -- will TypeError
  
  end)
  ```

### Breaking Changes
- users must specify system names when using tables to pass their systems
  ```luau
  loop:schedule({ system = function() end, name = "system name" })
  ```
  names returned by the SystemName function can be *quite* long, this change allows users to set a short and readable name for their system