### PR TITLE
Bug fix: Loop's methods incorrectly access private members

### DIFF
--- a/src/Loop.luau
+++ b/src/Loop.luau
@@ -98,7 +98,7 @@ function Loop:_collectSystemsUnderPhaseRecursive(systems, phase)
 		table.insert(systems, system)
 	end
 	for after in self._world:query(self._components.Phase):with(pair(self._components.DependsOn, phase)) do
-		self:collectSystemsUnderPhaseRecursive(systems, after)
+		self:_collectSystemsUnderPhaseRecursive(systems, after)
 	end
 end
 
@@ -118,7 +118,7 @@ function Loop:_collect()
 end
 
 function Loop:phase(after)
-	local phase = self.world:entity()
+	local phase = self._world:entity()
 	self._world:add(phase, self._components.Phase)
 	self._world:add(phase, pair(self._components.DependsOn, after))
 	return phase


### PR DESCRIPTION
This PR fixes broken indexes in [`Loop:phase()`](https://github.com/revvy02/Jam/blob/2db8106b7e2507bd70284d89ba2a1f03f763f3a3/src/Loop.luau#L121) and [`Loop:_collectSystemsUnderPhaseRecursive`](https://github.com/revvy02/Jam/blob/2db8106b7e2507bd70284d89ba2a1f03f763f3a3/src/Loop.luau#L101).